### PR TITLE
docs: lock SSOT start-here, constitution, and runbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,7 @@
+## 📌 Start Here (SSOT)
 
-[ops] test PR actions check
+- 🧭 HQ Dashboard (SSOT, single source of truth): https://github.com/sdhkor/A-System/blob/main/docs/HQ_DASHBOARD.md
+- 📜 Constitution v1.1: `docs/CONSTITUTION.md`
+- 📘 Runbook v1.0: `docs/RUNBOOK.md`
+
+> 운영 규칙: 진행상태(NOW/NEXT)는 SSOT에서만 업데이트. PR/Issue는 Evidence로만 남긴다.

--- a/docs/CONSTITUTION.md
+++ b/docs/CONSTITUTION.md
@@ -1,0 +1,76 @@
+# AI Quant Operating Constitution v1.1
+Project: R-System
+
+## 1. 목적
+R-System은 A-System 상단의 정책 통제 계층으로서, risk_state 입력을 평가하여 policy_decision을 산출한다.
+목표는 계좌 보호, 손실 제한, 운영 가드레일 유지다.
+
+## 2. 역할과 권한
+### HQ
+- 최종 의사결정권자
+- 정책 방향, 우선순위, 변경 승인
+- Gate 진행 승인
+- Dev/Val 지시
+
+### R-System Dev
+- 구현/운영 지원 담당
+- HQ 승인된 범위만 반영
+- 전략·정책 판단 금지
+- 항상 “현재 상태 보고 → 선택지 제시 → HQ 판단 대기” 순서로 행동
+
+## 3. 변경 통제
+다음 항목은 HQ 승인 없이 변경 금지:
+- 정책 의미/우선순위
+- 엔진 인터페이스(스키마/필드)
+- 운영 가드레일
+- main 보호 규칙
+- 테스트/승인 요구 조건
+
+정책 의미 또는 우선순위 변경이 필요하면 `needs:HqDecision`로 별도 상신한다.
+
+## 4. GitOps 운영 원칙
+- main 직접 push 금지
+- 모든 변경은 PR-only
+- required approval = 1
+- required check = `test`
+- administrators 포함 ruleset 적용
+- bypass 차단
+- 기본 merge 방식은 squash merge
+
+## 5. 증적 원칙
+모든 변경은 다음 4가지를 남긴다:
+- 무엇(What)
+- 근거(Evidence)
+- 리스크(Risk)
+- 롤백(Rollback)
+
+근거는 local test와 GitHub Actions 결과를 포함한다.
+
+## 6. 인시던트 처리
+운영 가드레일 위반 또는 우회 시:
+1. 사실 기록
+2. 영향 범위 확인
+3. 재발 방지 조치
+4. 증적 링크 첨부
+5. 종료 기록(close)
+
+## 7. SSOT 운영 원칙
+진행상태(NOW/NEXT)는 HQ Dashboard(SSOT)에서만 업데이트한다.
+R-System의 Issue/PR은 Evidence 저장소로만 사용한다.
+
+SSOT:
+- https://github.com/sdhkor/A-System/blob/main/docs/HQ_DASHBOARD.md
+
+## 8. 문서 박제
+다음 문서는 repo 운영의 기준 문서다:
+- `docs/CONSTITUTION.md`
+- `docs/RUNBOOK.md`
+
+README 상단 Start Here 링크와 pinned issue로 접근성을 고정한다.
+필요 시 태그로 문서 고정 버전을 남긴다.
+
+## 9. 우선순위
+안정성 > 통제 가능성 > 속도 > 확장성
+
+## 10. 효력
+본 헌장은 HQ 승인 시점부터 유효하며, 이후 변경은 PR + HQ 승인으로만 가능하다.

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -1,0 +1,76 @@
+# Runbook v1.0
+Project: R-System
+
+## 1. 목적
+R-System의 일상 운영, 변경 절차, 테스트, 병합, 인시던트 대응을 표준화한다.
+
+## 2. 기본 운영 원칙
+- main 직접 push 금지
+- 변경은 PR-only
+- local `pytest -q` 선행
+- GitHub Actions `test` PASS 확인 후 병합
+- required approval = 1 유지
+- squash merge 기본
+
+## 3. 표준 작업 절차
+1. `git switch main && git pull`
+2. `git switch -c <topic-branch>`
+3. 수정
+4. `pytest -q`
+5. `git add -A && git commit -m "<type>: <msg>"`
+6. `git push -u origin <topic-branch>`
+7. PR 생성
+8. Actions PASS 확인
+9. 승인 후 squash merge
+10. 브랜치 삭제(선택)
+
+## 4. 브랜치 네이밍 예시
+- `feat/r-...`
+- `fix/r-...`
+- `docs/r-...`
+- `test/r-...`
+- `chore/r-...`
+
+## 5. PR 최소 템플릿
+- 무엇(What)
+- 근거(Evidence)
+- 리스크(Risk)
+- 롤백(Rollback)
+
+예시:
+- local: `pytest -q` PASS
+- Actions: `test` PASS
+
+## 6. 변경 금지 항목
+HQ 승인 없이 금지:
+- 정책 의미/우선순위 변경
+- 인터페이스 스키마/필드 변경
+- 운영 가드레일 완화
+- 승인/체크 요구치 하향
+- main 보호 규칙 변경
+
+## 7. 핫픽스 원칙
+- 긴급 상황이어도 PR-only 원칙 유지
+- 사후 인시던트 로그 필수
+- bypass 사용 금지
+
+## 8. 롤백
+문제 발생 시:
+- 원칙: PR revert
+- 필요 시 이전 안정 커밋/태그 기준 복구
+- 정책 의미 변경이 수반되면 HQ 승인 후 진행
+
+## 9. SSOT 운영 원칙
+진행상태(NOW/NEXT)는 HQ Dashboard(SSOT)에서만 업데이트한다.
+Issue/PR은 Evidence 저장소로만 사용한다.
+
+SSOT:
+- https://github.com/sdhkor/A-System/blob/main/docs/HQ_DASHBOARD.md
+
+## 10. Start Here 유지
+README 상단에 다음 링크를 유지한다:
+- HQ Dashboard (SSOT)
+- Constitution
+- Runbook
+
+Pinned Start Here issue에는 일반 링크와 permalink를 함께 기록한다.


### PR DESCRIPTION
Refs #6

무엇(What):
- README 최상단에 Start Here(SSOT) 섹션 추가
- `docs/CONSTITUTION.md` 추가
- `docs/RUNBOOK.md` 추가
- SSOT(HQ Dashboard) 절대 링크 및 운영 규칙 반영

근거(Evidence):
- docs-only change
- policy logic / schema 변경 없음
- P0 SSOT 박제 기준 중 문서/README 항목 반영

리스크/롤백:
- risk: low
- rollback: PR revert

체크리스트:
- [ ] `docs/CONSTITUTION.md` 존재
- [ ] `docs/RUNBOOK.md` 존재
- [ ] README 최상단 Start Here(SSOT) 존재
- [ ] SSOT 절대 링크 확인
- [ ] policy 의미/우선순위 변경 없음